### PR TITLE
Uses xf.init() in cases of arity 3 transducer and arity 2 reducer 

### DIFF
--- a/base/reduce.js
+++ b/base/reduce.js
@@ -8,6 +8,10 @@ var transformer = require('../transformer/transformer'),
 module.exports =
 function reduce(xf, init, coll){
   xf = transformer(xf)
+  if (arguments.length === 2) {
+    coll = init
+    init = xf.init()
+  }
   if(isArray(coll)){
     return arrayReduce(xf, init, coll)
   }

--- a/base/transduce.js
+++ b/base/transduce.js
@@ -3,7 +3,11 @@ var transformer = require('../transformer/transformer'),
     reduce = require('./reduce')
 
 module.exports =
-function transduce(xf, f, init, coll){
-  f = transformer(f)
-  return reduce(xf(f), init, coll)
+function transduce(xf, f, init, coll) {
+  xf = xf(transformer(f))
+  if (arguments.length === 3) {
+    coll = init;
+    init = xf.init();
+  }
+  return reduce(xf, init, coll)
 }

--- a/test/base.js
+++ b/test/base.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var test = require('tape');
+var tr = require('../');
+
+test('transduce', function(t) {
+
+  var stringReduce = {
+    init: function() {
+      return '';
+    },
+    step: function(result, val) {
+      return result + val
+    },
+    result: function(result) {
+      return result;
+    }
+  }
+
+  t.equal(tr.transduce(tr.unique.dedupe(), stringReduce, '', ['a', 'b', 'b', 'c']), 'abc');
+  t.equal(tr.transduce(tr.unique.dedupe(), stringReduce, ['a', 'b', 'b', 'c']), 'abc');
+  t.end()
+})

--- a/test/base.js
+++ b/test/base.js
@@ -1,23 +1,30 @@
-'use strict';
+'use strict'
 
 var test = require('tape');
 var tr = require('../');
 
-test('transduce', function(t) {
-
-  var stringReduce = {
-    init: function() {
-      return '';
-    },
-    step: function(result, val) {
-      return result + val
-    },
-    result: function(result) {
-      return result;
-    }
+var stringReduce = {
+  init: function() {
+    return '';
+  },
+  step: function(result, val) {
+    return result + val
+  },
+  result: function(result) {
+    return result;
   }
+}
 
+test('transduce', function(t) {
   t.equal(tr.transduce(tr.unique.dedupe(), stringReduce, '', ['a', 'b', 'b', 'c']), 'abc');
   t.equal(tr.transduce(tr.unique.dedupe(), stringReduce, ['a', 'b', 'b', 'c']), 'abc');
+  t.end()
+})
+
+test('reduce', function(t) {
+  var reducer  = tr.unique.dedupe()(stringReduce);
+
+  t.equal(tr.reduce(reducer, '', ['a', 'b', 'b', 'c']), 'abc');
+  t.equal(tr.reduce(reducer, ['a', 'b', 'b', 'c']), 'abc');
   t.end()
 })


### PR DESCRIPTION
Hey, great work on these libs so far, really looking forward to using them in my projects & open source.

So the idea with this PR is that as defined in [clojure's transduce](http://clojure.github.io/clojure/branch-master/clojure.core-api.html#clojure.core/transduce) documentation, the `init` value from the xform should be used as the initializing value if none is provided. I've added the same pattern to the two arity form of `reduce`. I was going to combine these two so the check just passed through to the reduce, but that got a little ugly because you need to check `arguments.length` of each to be safe.

I have a few other ideas on some things that might be improvements (hasOwnProperty doesn't work with object created via `Object.create(null)` for one minor one), but unfortunately this is the only one I have time for right now. I'm sure as I start to integrate things into knex & bookshelf I'll be in here a lot.

Also :+1: on moving to a single project, maybe eventually it'll make sense to split up, but for now the functions are so small that being able to require them with paths seems like the way to go while the core is still being ironed out.