### PR TITLE
Explicitly run jshint on tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ clean:
 	rm -rf build
 
 test: | node_modules
+	`npm bin`/jshint array/*.js base/*.js iterator/*.js math/*.js push/*.js string/*.js transformer/*.js unique/*.js util/*.js test/*.js
 	`npm bin`/tape test/*.js
 
 node_modules:

--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "url": "https://github.com/transduce/transduce/issues"
   },
   "homepage": "http://github.com/transduce/transduce",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
-    "uglify-js": "~2.4.16",
+    "browserify": "~8.0.3",
+    "jshint": "^2.6.0",
     "tape": "~3.0.3",
-    "browserify": "~8.0.3"
+    "uglify-js": "~2.4.16"
   }
 }


### PR DESCRIPTION
Adds jshint as a dev dependency and run on appropriate directories with `make test`