### PR TITLE
Consistent use of xf / xform 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Currently supports the following functions:
 
 ```javascript
 // base functions
-reduce: function(f, init, coll)
-transduce: function(xf, f, init, coll)
+reduce: function(xf, init?, coll)
+transduce: function(t, xf, init?, coll)
 into: function(to, xf, from)
 toArray: function(xf?, coll)
 
@@ -57,8 +57,8 @@ math {
 
 push {
   tap: function(interceptor)
-  asCallback: function(xf, reducer)
-  asyncCallback: function(xf, continuation, reducer)
+  asCallback: function(t, reducer)
+  asyncCallback: function(t, continuation, reducer)
 }
 
 string {
@@ -82,7 +82,7 @@ iterator {
   iterable: function(value)
   iterator: function(value)
   toArray: function(value)
-  sequence: function(xf, value)
+  sequence: function(t, value)
 }
 
 transformer {
@@ -105,11 +105,11 @@ util {
 }
 ```
 
-##### reduce(f, init, coll)
-Reduces over a transformation, `f` is converted to a `transformer` and coll is converted to an `iterator`.   Arrays are special cased to reduce using for loop.
+##### reduce(xf, init?, coll)
+Reduces over a transformation. If `xf` is not a `transformer`, it is converted to one. `coll` is converted to an `iterator`. Arrays are special cased to reduce using for loop. If the function is called with arity-2, the `xf.init()` is used as the `init` value.
 
-##### transduce(xf, f, init, coll)
-Transduces over a transformation, `f` is converted to a `transformer` and the initialized transformer is passed to reduce.
+##### transduce(t, xf, init?, coll)
+Transduces over a transformation. The transducer `t` is initialized with `xf` and is passed to `reduce`. `xf` is converted to a `transformer` if it is not one already. If the function is called with arity-3, the `xf.init()` is used as the `init` value.
 
 ##### into(to, xf, from)
 Returns a new collection appending all items into the empty collection `to` by passing all items from source collection `from` through the transformation `xf`.  Chooses appropriate step function from type of `to`.  Can be array, object, string or have `@@transformer`.
@@ -202,10 +202,10 @@ Normally transducers are used with pull streams: reduce "pulls" values out of an
 ##### push.tap(interceptor)
 Transducer that invokes interceptor with each result and input, and then passes through input. The primary purpose of this method is to "tap into" a method chain, in order to perform operations on intermediate results within the chain.  Executes interceptor with current result and input.
 
-##### push.asCallback(xf, reducer)
+##### push.asCallback(t, reducer)
 Creates a callback that starts a transducer process and accepts parameter as a new item in the process. Each item advances the state of the transducer. If the transducer exhausts due to early termination, all subsequent calls to the callback will no-op and return the computed result. If the callback is called with no argument, the transducer terminates, and all subsequent calls will no-op and return the computed result. The callback returns undefined until completion. Once completed, the result is always returned. If reducer is not defined, maintains last value and does not buffer results.
 
-##### push.asyncCallback(xf, continuation, reducer)
+##### push.asyncCallback(t, continuation, reducer)
 Creates an async callback that starts a transducer process and accepts parameter cb(err, item) as a new item in the process. The returned callback and the optional continuation follow Node.js conventions with  fn(err, item). Each item advances the state  of the transducer, if the continuation is provided, it will be called on completion or error. An error will terminate the transducer and be propagated to the continuation.  If the transducer exhausts due to early termination, any further call will be a no-op. If the callback is called with no item, it will terminate the transducer process. If reducer is not defined, maintains last value and does not buffer results.
 
 
@@ -264,8 +264,8 @@ Supports anything that returns true for `isIterator` and converts arrays to iter
 ##### iterator.toArray(value)
 Converts the value to an iterator and iterates into an array.
 
-##### iterator.sequence(xf, value)
-Create an ES6 Iterable by transforming an input source using transducer `xf`.
+##### iterator.sequence(t, value)
+Create an ES6 Iterable by transforming an input source using transducer `t`.
 
 
 ### Transformer Protocol

--- a/base/transduce.js
+++ b/base/transduce.js
@@ -3,8 +3,8 @@ var transformer = require('../transformer/transformer'),
     reduce = require('./reduce')
 
 module.exports =
-function transduce(xf, f, init, coll) {
-  xf = xf(transformer(f))
+function transduce(t, xf, init, coll) {
+  xf = t(transformer(xf))
   if (arguments.length === 3) {
     coll = init;
     init = xf.init();

--- a/iterator/sequence.js
+++ b/iterator/sequence.js
@@ -4,17 +4,17 @@ var iterator = require('./iterator'),
     isReduced = require('../base/isReduced')
 
 module.exports =
-function sequence(xform, coll) {
-  return new LazyIterable(xform, coll)
+function sequence(t, coll) {
+  return new LazyIterable(t, coll)
 }
 
-function LazyIterable(xform, coll){
-  this.xform = xform
+function LazyIterable(t, coll){
+  this.t = t
   this.coll = coll
 }
 LazyIterable.prototype[symbol] = function(){
   var iter = iterator(this.coll)
-  return new LazyIterator(new Stepper(this.xform, iter))
+  return new LazyIterator(new Stepper(this.t, iter))
 }
 
 function LazyIterator(stepper){
@@ -46,8 +46,8 @@ StepTransformer.prototype.result = function(lt){
   return lt
 }
 
-function Stepper(xform, iter){
-  this.xf = xform(stepTransformer)
+function Stepper(t, iter){
+  this.xf = t(stepTransformer)
   this.iter = iter
 }
 Stepper.prototype.step = function(lt){

--- a/push/asCallback.js
+++ b/push/asCallback.js
@@ -16,14 +16,14 @@ var isReduced = require('../base/isReduced'),
 //
 // If reducer is not defined, maintains last value and does not buffer results.
 module.exports =
-function asCallback(xf, reducer){
+function asCallback(t, reducer){
   var done = false, stepper, result
 
   if(reducer === void 0){
     reducer = lastValue
   }
 
-  stepper = xf(reducer)
+  stepper = t(reducer)
   result = stepper.init()
 
   return function(item){

--- a/push/asyncCallback.js
+++ b/push/asyncCallback.js
@@ -16,14 +16,14 @@ var isReduced = require('../base/isReduced'),
 //
 // If reducer is not defined, maintains last value and does not buffer results.
 module.exports =
-function asyncCallback(xf, continuation, reducer){
+function asyncCallback(t, continuation, reducer){
   var done = false, stepper, result
 
   if(reducer === void 0){
     reducer = lastValue
   }
 
-  stepper = xf(reducer)
+  stepper = t(reducer)
   result = stepper.init()
 
   function checkDone(err, item){


### PR DESCRIPTION
One point of confusion I've spotted in other js transducer libs is the use of `xf` / `xform` to signal both a transducer and a transformer, depending on the function. This is likely an artifact from the translation from clojure, where `xf` is indeed both. This PR makes `xf` consistently to mean `transformer` or something which will be coerced to a `transformer` via `transform`. Transducers (arity-1 function returning a `tranformer`) use the variable `t`.

Also updated the docs to cover this change and the other merged arity change on `reduce` and `transduce`