### PR TITLE
Curry into, add toObject, toString

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,10 @@ Supports the following functions:
 reduce: function(xf, init?, coll)
 transduce: function(t, xf, init?, coll)
 eduction: function(t, coll)
-into: function(init, t?, coll)
-toArray: function(t?, coll)
+into: function(init, t?, coll?)
+toArray: function(t?, coll?)
+toObject: function(t?, coll?)
+toString: function(t?, coll?)
 
 // base transducers
 map: function(f)
@@ -229,11 +231,17 @@ Transduces over a transformation. The transducer `t` is initialized with `xf` an
 ##### eduction(t, coll)
 Creates an iterable and reducible application of the collection `coll` transformed by transducer`t`.  The returned eduction will be iterable using `sequence` and have a `reduce(rf, init)` method using `transduce`.
 
-##### into(init, t?, coll)
-Returns a new collection appending all items into `init` by passing all items from source collection `coll` through the optional transducer `t`.  Chooses transformer, `xf` from type of `to`.  Can be array, object, string or have `@@transformer`. `coll` is converted to an `iterator`
+##### into(init, t?, coll?)
+Returns a new collection appending all items into `init` by passing all items from source collection `coll` through the optional transducer `t`.  Chooses transformer, `xf` from type of `to`.  Can be array, object, string or have `@@transformer`. `coll` is converted to an `iterator`.  If `coll` is not provided, returns a curried function using `transformer` from `init` and the same transformation can be used for multiple collections.
 
-##### toArray(t?, coll)
-Transduce a collection into an array with an optional transducer, `t`. `coll` is converted to an `iterator`.
+##### toArray(t?, coll?)
+Transduce a collection into an array with an optional transducer, `t`. `coll` is converted to an `iterator`. If `coll` is not provided, returns a curried function using `transformer` from `init`.  Equivalent to `into([])`
+
+##### toObject(t?, coll?)
+Transduce a collection into an object with an optional transducer, `t`. `coll` is converted to an `iterator`. If `coll` is not provided, returns a curried function using `transformer` from `init`.  Equivalent to `into({})`
+
+##### toString(t?, coll?)
+Transduce a collection into an string with an optional transducer, `t`. `coll` is converted to an `iterator`. If `coll` is not provided, returns a curried function using `transformer` from `init`.  Equivalent to `into('')`
 
 #### Transducers
 

--- a/base/index.js
+++ b/base/index.js
@@ -9,6 +9,8 @@ module.exports = {
   eduction: require('./eduction'),
   into: require('./into'),
   toArray: require('./toArray'),
+  toString: require('./toString'),
+  toObject: require('./toObject'),
   map: require('./map'),
   filter: require('./filter'),
   remove: require('./remove'),

--- a/base/into.js
+++ b/base/into.js
@@ -1,14 +1,42 @@
 'use strict'
 var transduce = require('./transduce'),
+    reduce = require('./reduce'),
     transformer = require('../transformer/transformer'),
-    reduce = require('./reduce')
+    isFunction = require('../util/isFunction')
 
 module.exports =
 function into(init, t, coll){
-  var xf = transformer(init)
-  if (arguments.length === 2) {
+  var xf = transformer(init),
+      len = arguments.length
+
+  if(len === 1){
+    return intoCurryXf(xf)
+  }
+
+  if(len === 2){
+    if(isFunction(t)){
+      return intoCurryXfT(xf, t)
+    }
     coll = t
     return reduce(xf, init, coll)
   }
   return transduce(t, xf, init, coll)
+}
+
+function intoCurryXf(xf){
+  return function intoXf(t, coll){
+    if(arguments.length === 1){
+      if(isFunction(t)){
+        return intoCurryXfT(xf, t)
+      }
+      coll = t
+      return reduce(xf, xf.init(), coll)
+    }
+    return transduce(t, xf, xf.init(), coll)
+  }
+}
+function intoCurryXfT(xf, t){
+  return function intoXfT(coll){
+    return transduce(t, xf, xf.init(), coll)
+  }
 }

--- a/base/toObject.js
+++ b/base/toObject.js
@@ -1,3 +1,3 @@
 'use strict'
 var into = require('./into')
-module.exports = into([])
+module.exports = into({})

--- a/base/toString.js
+++ b/base/toString.js
@@ -1,3 +1,3 @@
 'use strict'
 var into = require('./into')
-module.exports = into([])
+module.exports = into('')


### PR DESCRIPTION
Creates a function that transduces over a supplied `coll`.  The same `transduction` can be used with multiple collections.  If `xf` is not a transformer, it is converted to one.  `xf.init()` is called for each collection to create an initial value.

Example
```javascript
tx = tr.transduction(tr.compose(tr.map(add(1)), tr.filter(isEven)), [])
[[1,2,3], [2,3,4], [5,6,7]].map(tx)
// [[2,4], [4], [6,8]])

tx = tr.transduction(tr.partitionAll(2), {c: 'd'})
tx(['a', 'b', 'b', 'c'])
// {a: 'b', b: 'c', c: 'd'})
```