### PR TITLE
Use tInit in into implementation

### DIFF
--- a/src/_internal.js
+++ b/src/_internal.js
@@ -54,9 +54,9 @@ export function intoImpl(reduce){
         return intoCurryXfT(xf, t)
       }
       coll = t
-      return reduce(xf, init, coll)
+      return reduce(xf, xf[tInit](), coll)
     }
-    return reduce(t(xf), init, coll)
+    return reduce(t(xf), xf[tInit](), coll)
   }
 
   function intoCurryXf(xf){

--- a/test/core.js
+++ b/test/core.js
@@ -135,6 +135,16 @@ test('into', function(t) {
   t.deepEqual(toObject(tr.partitionAll(2), ['a', 'b', 'b', 'c']), {a: 'b', b: 'c'})
   t.deepEqual(toObject(tr.partitionAll(2))(['a', 'b', 'b', 'c']), {a: 'b', b: 'c'})
 
+  var intoInit = {}
+  intoInit[tp.init] = function() { return [4] }
+  intoInit[tp.step] = function(value, input) { 
+    value.push(input)
+    return value
+  }
+  intoInit[tp.result] = tr.identity
+
+  t.deepEqual(tr.into(intoInit, [1, 2, 3]), [4, 1, 2, 3])
+
   t.end()
 })
 


### PR DESCRIPTION
I think this is the essence of what I was after in #48 - not so sure about the static `tInit` use case yet.

I think there's still some room for improvement with some of the internal semantics but it feels like if you pass an object with `tInit` as the first arg of into, it should use that for determining the initial value (as it does in the curried into fns.