### PR TITLE
Added self-returning [symIter] method to created iterators

### DIFF
--- a/src/_internal.js
+++ b/src/_internal.js
@@ -240,5 +240,5 @@ const objectTransformer = {
 }
 
 function symIterReturnSelf() {
-  return this;
+  return this
 }

--- a/src/_internal.js
+++ b/src/_internal.js
@@ -127,7 +127,8 @@ export class ArrayIterable {
           return {done: true}
         }
         return {done: false, value: this.arr[idx++]}
-      }
+      },
+      [symIter]: symIterReturnSelf
     }
   }
 }
@@ -137,7 +138,7 @@ export class FunctionIterable {
     this.fn = fn
   }
   [symIter](){
-    return {next: this.fn}
+    return { next: this.fn, [symIter]: symIterReturnSelf }
   }
 }
 
@@ -155,7 +156,8 @@ export class ObjectIterable {
         }
         var key = this.keys[idx++]
         return {done: false, value: [key, this.obj[key]]}
-      }
+      },
+      [symIter]: symIterReturnSelf
     }
   }
 }
@@ -235,4 +237,8 @@ const objectTransformer = {
     return result
   },
   [tResult]: identity
+}
+
+function symIterReturnSelf() {
+  return this;
 }

--- a/test/core.js
+++ b/test/core.js
@@ -305,6 +305,7 @@ test('iterate array', function(t){
   idx = 0
   arr = [1,2,3]
   iterator = tr.iterable(arr)[symbol]()
+  t.equals(iterator, iterator[symbol](), 'iterator === iterator[symbol]()')
   t.deepEquals({value: arr[idx++], done: false}, iterator.next())
   t.deepEquals({value: arr[idx++], done: false}, iterator.next())
   t.deepEquals({value: arr[idx++], done: false}, iterator.next())
@@ -333,6 +334,7 @@ test('iterate string', function(t){
   idx = 0
   arr = ['1','2','3']
   iterator = tr.iterable('123')[symbol]()
+  t.equals(iterator, iterator[symbol](), 'iterator === iterator[symbol]()')
   t.deepEquals({value: arr[idx++], done: false}, iterator.next())
   t.deepEquals({value: arr[idx++], done: false}, iterator.next())
   t.deepEquals({value: arr[idx++], done: false}, iterator.next())
@@ -355,11 +357,14 @@ test('iterate string', function(t){
 })
 
 test('iterate object', function(t){
-  var obj, arr
+  var obj, objIterator, arr, symbol = tr.protocols.iterator
   var toArray = iterdone.toArray
 
   obj = {a:1, b:2, c:3}
   arr = [['a', 1],['b', 2],['c', 3]]
+
+  objIterator = tr.iterator(obj)
+  t.equals(objIterator, objIterator[symbol](), 'objIterator === objIterator[symbol]()')
 
   t.deepEqual(tr.into([], tr.iterable(obj)), arr)
   t.deepEqual(toArray(obj).sort(), arr)
@@ -380,6 +385,7 @@ test('iterate fn', function(t){
 
   start = 0
   iterator = tr.iterable(count(start))[symbol]()
+  t.equals(iterator, iterator[symbol](), 'iterator === iterator[symbol]()')
   t.deepEquals({value: start++, done: false}, iterator.next())
   t.deepEquals({value: start++, done: false}, iterator.next())
   t.deepEquals({value: start++, done: false}, iterator.next())


### PR DESCRIPTION
Hi!

I thought this would be a useful tweak: I noticed that the iterators produced by the `transduce.iterator` method (or `.iterable(value)[Symbol.iterator]`) lack a self-returning `Symbol.iterator` method of their own. This is a minor part of iterator protocol that makes iterators compatible with a number of ES6 features, including the spread operator, `Promise.all`, `Array.from`, `new Map`, `new Set`, `for...of`, `yield*`, etc. Full compatibility can be useful on occasion for, among other things, working directly with iterators for lazy evaluation purposes, and adding it here will prevent a surprise error for people who try using these features on `transduce` iterators.